### PR TITLE
Fix Node 22 import attribute syntax: assert -> with

### DIFF
--- a/build.js
+++ b/build.js
@@ -6,10 +6,10 @@ import { hideBin } from 'yargs/helpers';
 const argv = yargs(hideBin(process.argv)).argv
 // rollup dependencies
 import * as rollup from 'rollup';
-import activitiesJSON from './src/activities.json' assert { type: 'json' };
-import audiencesJSON from './src/audiences.json' assert { type: 'json' };
-import locationsJSON from './src/locations.json' assert { type: 'json' };
-import sitesJSON from './src/sites.json' assert { type: 'json' };
+import activitiesJSON from './src/activities.json' with { type: 'json' };
+import audiencesJSON from './src/audiences.json' with { type: 'json' };
+import locationsJSON from './src/locations.json' with { type: 'json' };
+import sitesJSON from './src/sites.json' with { type: 'json' };
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import commonjs from '@rollup/plugin-commonjs';


### PR DESCRIPTION
## Summary

- Node 22 removed the V8-only `assert` keyword for import attributes; the standardized replacement is `with`.
- Updates `build.js` lines 9-12 to use `with { type: 'json' }`.

## Why

GitHub bumped the `ubuntu-latest` runner image to `ubuntu24/20260513.135` on 2026-05-19, which has a Node 22 on PATH that hard-fails `assert` with `SyntaxError: Unexpected identifier 'assert'`.

This broke HPE-altloader's deploy workflows:

- **`ci-deploy-fe-altloader.yml`** — visibly failing in red since 2026-05-19 19:35 UTC, triggering `🚨 CRITICAL` Slack alerts in `#hpe-funnelenvy-altloader`. No `continue-on-error` on the build step.
- **`ci-deploy-b2c-v2.yml` / `ci-deploy-b2b-hybris-v2.yml` / `ci-deploy-configurator-v2.yml`** — silently broken; the build step has `continue-on-error: true`, so the same crash leaves `./dist` empty but the workflow reports green. Activity changes intermittently fail to ship.
- **`rebuild-all-activities.yml`** — visibly failing.

## Reference

- [Node.js v20 to v22 migration guide](https://nodejs.org/en/blog/migrations/v20-to-v22)
- [PR #52104: esm: drop support for import assertions](https://github.com/nodejs/node/pull/52104)
- Runner image: [ubuntu24/20260513.135](https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260513.135)

## Test plan

- [ ] Merge to `main`
- [ ] Verify `Deploy FE Altloader v2` succeeds on the next HPE-altloader push
- [ ] Verify the silent-failure deploys produce a non-empty `./dist` again
- [ ] Confirm `🚨 CRITICAL` Slack alerts stop firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)