### PR TITLE
Make configurator iframe FE_ param forwarding race-proof

### DIFF
--- a/init-activities.js
+++ b/init-activities.js
@@ -410,29 +410,72 @@ function createEnvironmentIndicator() {
 function passQueryParametersToB2BConfiguratorIFrame() {
 	// only run on cart configuration page
 	if (window.location.pathname.indexOf('/cart/configure') === -1) return;
-	const IFRAME_ID = 'configure_cart';
-	const alterIframeSrc = () => {
-	const iframe = document.getElementById(IFRAME_ID);
-		if (iframe && iframe.src) {
-			const pageParams = new URLSearchParams(window.location.search);
-			const srcURL = new URL(iframe.src);
-			const variants = pageParams.has(VARIATIONS_QUERY_PARAMETER) ? pageParams.get(VARIATIONS_QUERY_PARAMETER) : null;
-			const environment = pageParams.has(ENV_QUERY_PARAMETER) ? pageParams.get(ENV_QUERY_PARAMETER) : null;
 
-			if (environment) {
-				srcURL.searchParams.set(ENV_QUERY_PARAMETER, environment);
-			}
-			if (variants) {
-				srcURL.searchParams.set(VARIATIONS_QUERY_PARAMETER, variants);
-			}
-			iframe.src = srcURL.toString();
+	// The configurator runs as a cross-origin iframe (occ-ext.wip.it.hpe.com), so the parent's
+	// cookie/localStorage cannot reach it — forwarding FE_ params via the iframe src URL is the
+	// only bridge. Read the desired values from the parent URL once.
+	const pageParams = new URLSearchParams(window.location.search);
+	const environment = pageParams.has(ENV_QUERY_PARAMETER) ? pageParams.get(ENV_QUERY_PARAMETER) : null;
+	const variants = pageParams.has(VARIATIONS_QUERY_PARAMETER) ? pageParams.get(VARIATIONS_QUERY_PARAMETER) : null;
+
+	// Nothing to forward — never touch the iframe src (a redundant reassignment would force an
+	// extra iframe navigation, re-loading fe_altloader.js inside the iframe for no reason).
+	if (!environment && !variants) return;
+
+	const IFRAME_ID = 'configure_cart';
+
+	// True when the iframe src already carries exactly the FE_ values we want — the idempotency
+	// guard that both avoids a needless reload and prevents an infinite MutationObserver loop
+	// (our own src write re-triggers the observer, which must then no-op).
+	const srcHasDesiredParams = (src) => {
+		try {
+			const sp = new URL(src).searchParams;
+			if (environment && sp.get(ENV_QUERY_PARAMETER) !== environment) return false;
+			if (variants && sp.get(VARIATIONS_QUERY_PARAMETER) !== variants) return false;
+			return true;
+		} catch (err) {
+			return false;
 		}
+	};
+
+	// Append the FE_ params when the src is populated but missing/stale. Returns true only when it
+	// actually rewrote the src.
+	const applyParams = (iframe) => {
+		if (!iframe || !iframe.src) return false;      // src not set yet — wait for a real value
+		if (srcHasDesiredParams(iframe.src)) return false; // already correct — do not reload
+		let srcURL;
+		try {
+			srcURL = new URL(iframe.src);
+		} catch (err) {
+			return false;
+		}
+		if (environment) {
+			srcURL.searchParams.set(ENV_QUERY_PARAMETER, environment);
+		}
+		if (variants) {
+			srcURL.searchParams.set(VARIATIONS_QUERY_PARAMETER, variants);
+		}
+		iframe.src = srcURL.toString();
+		return true;
 	};
 
 	window.feUtils.waitForConditions({
 		conditions: [`iframe#${IFRAME_ID}`],
 		activity: 'fe-altloader',
-		callback: alterIframeSrc,
+		callback: () => {
+			const iframe = document.getElementById(IFRAME_ID);
+			if (!iframe) return;
+
+			// Server-rendered-src case: the src is already present, apply immediately.
+			applyParams(iframe);
+
+			// JS-set-late case: Hybris assigns/re-assigns the src asynchronously (after the
+			// token fetch), which the one-shot callback would otherwise miss. Watch the src
+			// attribute and re-apply whenever it changes without our params. The idempotency
+			// guard in applyParams terminates the loop after our own write.
+			const observer = new MutationObserver(() => applyParams(iframe));
+			observer.observe(iframe, { attributes: true, attributeFilter: ['src'] });
+		},
 	});
 }
 

--- a/init-activities.js
+++ b/init-activities.js
@@ -461,8 +461,10 @@ function passQueryParametersToB2BConfiguratorIFrame() {
 
 	window.feUtils.waitForConditions({
 		conditions: [`iframe#${IFRAME_ID}`],
-		activity: 'fe-altloader',
+		activity: 'fe_altloader',
 		callback: () => {
+			// Assumes Hybris mutates the src of this existing element rather than swapping in a
+			// new iframe node; the observed behavior sets .src after a token fetch.
 			const iframe = document.getElementById(IFRAME_ID);
 			if (!iframe) return;
 
@@ -472,7 +474,8 @@ function passQueryParametersToB2BConfiguratorIFrame() {
 			// JS-set-late case: Hybris assigns/re-assigns the src asynchronously (after the
 			// token fetch), which the one-shot callback would otherwise miss. Watch the src
 			// attribute and re-apply whenever it changes without our params. The idempotency
-			// guard in applyParams terminates the loop after our own write.
+			// guard in applyParams terminates the loop after our own write. Left connected for
+			// the page lifetime on purpose, so any later re-assignment is also corrected.
 			const observer = new MutationObserver(() => applyParams(iframe));
 			observer.observe(iframe, { attributes: true, attributeFilter: ['src'] });
 		},


### PR DESCRIPTION
## Problem

Two issues on the B2B configurator (`/cart/configure`), where the configurator runs as a **cross-origin iframe** (`#configure_cart`, origin `occ-ext.wip.it.hpe.com`) embedded in the Hybris parent (`buy.hpe.com`). Because per-origin cookie/localStorage can't cross origins, forwarding `FE_LOADER`/`FE_VARIANT` from the parent URL into the iframe `src` is the only bridge that lets the configurator's own in-iframe `fe_altloader.js` pick them up.

1. **Inconsistent FE_ param forwarding.** The old code used a one-shot `waitForConditions` callback fired when the iframe *element* exists, guarded by `if (iframe && iframe.src)` with no retry. When Hybris sets the iframe `src` asynchronously (after a token fetch) *after* the callback runs, params were never applied → params missing from the iframe src (observed: `FE_VARIANT` never, `FE_LOADER` sometimes, depending on whether the src was server-rendered vs JS-set-late).
2. **`fe_altloader.js` loading multiple times inside the iframe.** The old code always reassigned `iframe.src` (even with no params), forcing extra iframe navigations that re-fetch `fe_altloader.js` (observed 1–3× in-iframe vs 1× standalone).

## Fix

`init-activities.js` — `passQueryParametersToB2BConfiguratorIFrame`:

- Read the desired `FE_LOADER`/`FE_VARIANT` from the parent URL once; **return early when neither is present** so the iframe `src` is never touched needlessly (removes the redundant navigation behind issue #2).
- Wait for a **non-empty** src, then apply params, and **re-apply via a `MutationObserver`** on the `src` attribute so a late/async Hybris assignment no longer drops them (fixes issue #1).
- **Idempotency guard** (`srcHasDesiredParams`): rewrite only when params are missing/stale — prevents an infinite observer loop and any extra reloads.

## Verification

- Local `--lib` build passes; new logic present in the emitted bundle.
- Fresh-context code review: no blocking findings. Loop-safety proven — both write and read paths use `URLSearchParams`, so the `%3A`-encoded colon in the variant value round-trips equal and the guard terminates the loop.

## Notes for QA

- One **intentional** iframe reload remains in the param case (injecting query params requires re-navigating the iframe); the fix removes the *extra* bounces, not that single necessary one.
- The forwarding *failure* reproduces only when the page sets the iframe src late via JS (which the fix targets). Confirm via the DevTools `src`-hook on a failing page, and QA via the Resource Override workflow (this PR auto-builds a test copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)